### PR TITLE
fix: depends on unknown job job-sync-docs-to-wiki

### DIFF
--- a/.github/workflows/pull-complete.yml
+++ b/.github/workflows/pull-complete.yml
@@ -200,7 +200,6 @@ jobs:
     needs:
       - createBranch
       - update_release_draft
-      - job-sync-docs-to-wiki
       - create-changelog
     steps:
       - uses: technote-space/load-config-action@v1


### PR DESCRIPTION
 Check failure on line 1 in .github/workflows/pull-complete.yml


GitHub Actions
/ Release Management

Invalid workflow file
The workflow is not valid. Job misc depends on unknown job job-sync-docs-to-wiki.